### PR TITLE
Task#120101

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -114,6 +114,9 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
         closePos() {
             this.trigger('close-pos');
         }
+        closeReload() {
+            window.location = '/web#action=point_of_sale.action_client_pos_menu';
+        }
         async closeSession() {
             if (this.canCloseSession() && !this.closeSessionClicked) {
                 this.closeSessionClicked = true;
@@ -151,7 +154,7 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
                     if (!response.successful) {
                         return this.handleClosingError(response);
                     }
-                    window.location = '/web#action=point_of_sale.action_client_pos_menu';
+                    this.closeReload();
                 } catch (error) {
                     const iError = identifyError(error);
                     if (iError instanceof ConnectionLostError || iError instanceof ConnectionAbortedError) {


### PR DESCRIPTION
refactor(ClosePosPopup): Modulamos un window.location para poder heredar de este método sin que refresque

La alternativa es añadir un listener beforeunload pero al hacer el preventDefault devuelve un alert preguntando al usuario si salir o Cancelar, por lo que queda raro. De esta forma únicamente tenemos que heredar del método que hace el location y llamar o no al super.